### PR TITLE
Accept alternative CA file and/or directory as preprocessor options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ OPTFLAGS += -DSETPROCTITLE -DSPT_TYPE=2
 # DARWIN
 #OPTFLAGS += -DDARWIN
 
+# DARWIN, continued, if compiling for macOS with Homebrew
+#CFLAGS += -I/usr/local/opt/openssl/include
+#LDFLAGS += -L/usr/local/opt/openssl/lib
+#OPTFLAGS += -DDEFAULT_CA_FILE='"/usr/local/etc/openssl@1.1/cacert.pem"'
+#OPTFLAGS += -DDEFAULT_CA_DIR=NULL
+
 # CYGWIN
 #OPTFLAGS += -DCYGWIN
 

--- a/docs/proxytunnel.1.adoc
+++ b/docs/proxytunnel.1.adoc
@@ -69,7 +69,8 @@ also be used for other proxy-traversing purposes like proxy bouncing.
 *-C*, *--cacert*=_filename/directory_::
     Specify a CA certificate file (or directory containing CA certificate(s))
     to trust when verifying a server SSL certificate. If a directory is provided,
-    it must be prepared with OpenSSL's c_rehash tool. (default: /etc/ssl/certs)
+    it must be prepared with OpenSSL's c_rehash tool. (default, unless changed at
+    compile time using DEFAULT_CA_FILE or DEFAULT_CA_DIR options: /etc/ssl/certs)
 
 *-F*, *--passfile*=_filename_::
     Use _filename_ for reading username and password for HTTPS proxy

--- a/ptstream.c
+++ b/ptstream.c
@@ -266,7 +266,7 @@ int stream_enable_ssl(PTSTREAM *pts, const char *proxy_arg) {
 #ifndef DEFAULT_CA_FILE
 	const char *ca_file = NULL;
 #else
-	const char *ca_file = DEFAULT_CA_FILE; /* Default cert file from in Makefile */
+	const char *ca_file = DEFAULT_CA_FILE; /* Default cert file from Makefile */
 #endif /* !DEFAULT_CA_FILE */
 #ifndef DEFAULT_CA_DIR
 	const char *ca_dir = "/etc/ssl/certs/"; /* Default cert directory if none given */

--- a/ptstream.c
+++ b/ptstream.c
@@ -263,13 +263,16 @@ int stream_enable_ssl(PTSTREAM *pts, const char *proxy_arg) {
 	X509* cert = NULL;
 	int status;
 	struct stat st_buf;
-#ifndef LOCAL_OPENSSL11
+#ifndef DEFAULT_CA_FILE
 	const char *ca_file = NULL;
+#else
+	const char *ca_file = DEFAULT_CA_FILE; /* Default cert file from in Makefile */
+#endif /* !DEFAULT_CA_FILE */
+#ifndef DEFAULT_CA_DIR
 	const char *ca_dir = "/etc/ssl/certs/"; /* Default cert directory if none given */
 #else
-	const char *ca_file = "/usr/local/etc/openssl@1.1/cacert.pem";
-	const char *ca_dir = NULL;
-#endif /* !LOCAL_OPENSSL11 */
+	const char *ca_dir = DEFAULT_CA_DIR;  /* Default cert directory from Makefile */
+#endif /* !DEFAULT_CA_DIR */
 	long vresult;
 	char *peer_host = NULL;
 	char proxy_arg_fmt[32];

--- a/ptstream.c
+++ b/ptstream.c
@@ -263,8 +263,13 @@ int stream_enable_ssl(PTSTREAM *pts, const char *proxy_arg) {
 	X509* cert = NULL;
 	int status;
 	struct stat st_buf;
+#ifndef LOCAL_OPENSSL11
 	const char *ca_file = NULL;
 	const char *ca_dir = "/etc/ssl/certs/"; /* Default cert directory if none given */
+#else
+	const char *ca_file = "/usr/local/etc/openssl@1.1/cacert.pem";
+	const char *ca_dir = NULL;
+#endif /* !LOCAL_OPENSSL11 */
 	long vresult;
 	char *peer_host = NULL;
 	char proxy_arg_fmt[32];


### PR DESCRIPTION
Currently, `proxytunnel` looks by default for a CA certificate file in `/etc/ssl/certs`, but on current versions of macOS, that directory is always empty. This has the effect that, to use `proxytunnel` on macOS (as shipped with Homebrew, for example), one must always specify a `--cacert` path at runtime. This PR provides a means to change the default CA directory or file at compile time. 

<details>
<summary>For example, to compile in a sensible new default CA file path on macOS with Homebrew, …</summary>
include (or, in this case, uncomment) these options in the main `Makefile`:

```
CFLAGS += -I/usr/local/opt/openssl/include
LDFLAGS += -L/usr/local/opt/openssl/lib
OPTFLAGS += -DDEFAULT_CA_FILE='"/usr/local/etc/openssl@1.1/cacert.pem"'
OPTFLAGS += -DDEFAULT_CA_DIR=NULL
```
</details>