### PR TITLE
Handle variable prefix path during build as well as install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,17 +29,17 @@ OPTFLAGS += -DSETPROCTITLE -DSPT_TYPE=2
 #OPTFLAGS += -DHAVE_SYS_PSTAT_H
 
 # DARWIN
-OPTFLAGS += -DDARWIN
+#OPTFLAGS += -DDARWIN
 
 # DARWIN, continued, if compiling for macOS with Homebrew
-openssl_bin = $(prefix)/opt/openssl/bin/openssl
-cacert_dir = $(shell "$(openssl_bin)" version -d | sed -E 's/^[^"]+"|"$$//g')
-cacert_file = $(cacert_dir)/cacert.pem
+#openssl_bin = $(prefix)/opt/openssl/bin/openssl
+#cacert_dir = $(shell "$(openssl_bin)" version -d | sed -E 's/^[^"]+"|"$$//g')
+#cacert_file = $(cacert_dir)/cacert.pem
 
-CFLAGS += -I$(prefix)/opt/openssl/include
-LDFLAGS += -L$(prefix)/opt/openssl/lib
-OPTFLAGS += -DDEFAULT_CA_FILE='$(subst ','"'"',$(subst \,\\,$(shell gls --quoting-style=c "$(cacert_file)")))'
-OPTFLAGS += -DDEFAULT_CA_DIR=NULL
+#CFLAGS += -I$(prefix)/opt/openssl/include
+#LDFLAGS += -L$(prefix)/opt/openssl/lib
+#OPTFLAGS += -DDEFAULT_CA_FILE='$(subst ','"'"',$(subst \,\\,$(shell gls --quoting-style=c "$(cacert_file)")))'
+#OPTFLAGS += -DDEFAULT_CA_DIR=NULL
 
 # CYGWIN
 #OPTFLAGS += -DCYGWIN

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,6 @@ bindir = $(prefix)/bin
 datadir = $(prefix)/share
 mandir = $(datadir)/man
 
-openssl_bin = $(prefix)/opt/openssl/bin/openssl
-cacert_dir = $(shell "$(openssl_bin)" version -d | cut -d'"' -f2)
-cacert_file = $(cacert_dir)/cacert.pem
-
 CC ?= cc
 CFLAGS ?= -Wall -O2 -ggdb
 
@@ -36,6 +32,10 @@ OPTFLAGS += -DSETPROCTITLE -DSPT_TYPE=2
 OPTFLAGS += -DDARWIN
 
 # DARWIN, continued, if compiling for macOS with Homebrew
+openssl_bin = $(prefix)/opt/openssl/bin/openssl
+cacert_dir = $(shell "$(openssl_bin)" version -d | cut -d'"' -f2)
+cacert_file = $(cacert_dir)/cacert.pem
+
 CFLAGS += -I$(prefix)/opt/openssl/include
 LDFLAGS += -L$(prefix)/opt/openssl/lib
 OPTFLAGS += -DDEFAULT_CA_FILE='$(subst ','"'"',$(subst \,\\,$(shell gls --quoting-style=c "$(cacert_file)")))'

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ OPTFLAGS += -DDARWIN
 # DARWIN, continued, if compiling for macOS with Homebrew
 CFLAGS += -I$(prefix)/opt/openssl/include
 LDFLAGS += -L$(prefix)/opt/openssl/lib
-OPTFLAGS += -DDEFAULT_CA_FILE=$(shell echo "'$$(gls --quoting-style=c "$(cacert_file)")'")
+OPTFLAGS += -DDEFAULT_CA_FILE='$(subst ','"'"',$(subst \,\\,$(shell gls --quoting-style=c "$(cacert_file)")))'
 OPTFLAGS += -DDEFAULT_CA_DIR=NULL
 
 # CYGWIN

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 name = proxytunnel
 version = $(shell awk 'BEGIN { FS="\"" } /^\#define VERSION / { print $$2 }' config.h)
 
-prefix = $(shell brew --prefix)
+prefix = /usr/local
 bindir = $(prefix)/bin
 datadir = $(prefix)/share
 mandir = $(datadir)/man

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OPTFLAGS += -DDARWIN
 
 # DARWIN, continued, if compiling for macOS with Homebrew
 openssl_bin = $(prefix)/opt/openssl/bin/openssl
-cacert_dir = $(shell "$(openssl_bin)" version -d | cut -d'"' -f2)
+cacert_dir = $(shell "$(openssl_bin)" version -d | sed -E 's/^[^"]+"|"$$//g')
 cacert_file = $(cacert_dir)/cacert.pem
 
 CFLAGS += -I$(prefix)/opt/openssl/include


### PR DESCRIPTION
The options added for compiling for macOS with Homebrew assumed the prefix `/usr/local` at compile time. This patch provides a means to handle a different prefix when compiling.